### PR TITLE
[CLD-2913] Support short keys for git project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ are rapidly changing. This differs from existing solutions such as git sub-modul
 best when sub-repositories are mostly stable.
 
 git-project keeps track of which branches you should be on in all your repositories when you are working
-on a given feature. So, if you're working on feature X on a given branch in your main repository, which depends
-on branch Y in sub-repo A and branch X in sub-repo B, git-project keeps track of that for you! Then, if you want
+on a given feature. So, if you're working on :code:`feature X` on a given branch in your main repository, which depends
+on :code:`branch Y` in :code:`sub-repo A` and :code:`branch X` in :code:`sub-repo B`, git-project keeps track of that for you! Then, if you want
 to stop and work on a different feature that depends on an entirely different set of branches, you can switch to it
 with a single command.
 

--- a/README.rst
+++ b/README.rst
@@ -66,33 +66,34 @@ Saving
 ======
 
 To save the current *state* of all subrepositories, call 
-    :code:`git project save`
+
+:code:`git project save`
 
 To save only certain specified repositories, use 
 
-    :code:`git project save -- repo1-name repo2-name ...` 
+:code:`git project save -- repo1-name repo2-name ...` 
 
 This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
 You should then add and commit the .gitproj file like normal:
 
-    :code:`git add .gitproj && git commit -m "Update gitproj"`
+:code:`git add .gitproj && git commit -m "Update gitproj"`
 
 Loading
 =======
 
 To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run 
 
-    :code:`git project load`. 
+:code:`git project load`. 
 
 This resets your subrepository's local branch to the commit stored in the .gitproj file. If you have unpushed changes in the subrepository, you will be prompted to push these before updating your branch to ensure your commits aren't orphaned.
 
 If you want to load the exact commits on detached heads rather than resetting your local branch, use 
 
-    :code:`git project load --commit`.
+:code:`git project load --commit`.
 
 Similar to saving, you can load only specific repositories with 
 
-    :code:`git project load -- repo1-name repo2-name`
+:code:`git project load -- repo1-name repo2-name`
 
 
 Other

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,11 @@ Setup
 Usage
 *****
 
-git-project saves the *state* of your repository and subrepositories. A *state* is the collection of feature branches for
+git-project is used to save and load the *state* of your repository and subrepositories. A *state* is the collection of feature branches for
 each repository.
+
+Saving
+======
 
 To save the *state*, call :code:`git project save` to save the current state of all subrepositories 
 
@@ -68,6 +71,9 @@ To save only certain specified repositories, use :code:`git project save -- repo
 
 This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
 You should then add and commit the .gitproj file like normal: :code:`git add .gitproj && git commit -m "Update gitproj"`
+
+Loading
+=======
 
 To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run :code:`git project load`. 
 
@@ -79,6 +85,10 @@ To return to this *state* later, just switch to the branch in your base reposito
 
 .. tip::
     Similar to saving, you can load only specific repositories with :code:`git project load -- repo1-name repo2-name`
+
+
+Other
+=====
 
 Optional parameters are:
 

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,15 @@
+###########
 git-project
-***********
+###########
 
 .. image:: https://travis-ci.org/aranzgeo/git-project.svg?branch=master&branch=master
     :target: https://travis-ci.org/aranzgeo/git-project
 
 Scripts extending git for better project and sub-repository management
 
+*******
 Purpose
--------
+*******
 
 git-project serves as an alternative to other git sub-module/sub-repo solutions.
 It is meant to be used in situations where both the parent repository and sub-repositories
@@ -21,16 +23,18 @@ to stop and work on a different feature that depends on an entirely different se
 with a single command.
 
 
+*******
 Install
--------
+*******
 
 Run :code:`make install` (or :code:`sudo make install`)
 This will install the git-project python script into your /usr/local/bin/.
 
 To uninstall, simply run :code:`make uninstall`
 
+*****
 Setup
------
+*****
 
 1. Create a .gitproj file with the format
 
@@ -48,20 +52,19 @@ Setup
 
 2. Run :code:`git project init` from the root of your project. This will attempt to clone the sub-repositories and add them to your .gitignore. 
 
-    .. note::
-        If you have already cloned the sub-repositories, skip the :code:`git project init` step, but make sure the sub-repositories are listed in your .gitignore.
+    If you have already cloned the sub-repositories, skip the :code:`git project init` step, but make sure the sub-repositories are listed in your .gitignore.
 
 
+*****
 Usage
------
+*****
 
 git-project saves the *state* of your repository and subrepositories. A *state* is the collection of feature branches for
 each repository.
 
 To save the *state*, call :code:`git project save` to save the current state of all subrepositories 
 
-.. tip:: 
-    To save only certain specified repositories, use :code:`git project save -- repo1-name repo2-name ...` 
+To save only certain specified repositories, use :code:`git project save -- repo1-name repo2-name ...` 
 
 This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
 You should then add and commit the .gitproj file like normal: :code:`git add .gitproj && git commit -m "Update gitproj"`
@@ -88,8 +91,9 @@ Optional parameters are:
     -- : when saving, separates flags from the list of repos to save. If not specified, all repos will be saved
 
 
+****
 Bugs
-----
+****
 
 If you run into any problems with `git-project`, please make an
 `issue <https://github.com/aranzgeo/git-project/issues>`_

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,15 @@ Setup
         subrepo1-name local/path/to/repo1 remote-url-subrepo1
         subrepo2-name local/path/to/repo2 remote-url-subrepo2
 
+The first column (subrepo-name) is a memorable key for each repository that you will use when saving or loading that repo (see below)
+The second column is the local directory where you would like to store each repository (relative to the .gitproj file)
+The final column is the remote url from which to clone the repository.
+
 2. Run :code:`git project init` from the root of your project. This will attempt to clone the sub-repositories
 and add them to your .gitignore. 
 
 .. note::
-    If you have already cloned the sub-repositories, skip running :code:`git project init`, but make sure the sub-repositories are listed in your .gitignore.
+If you have already cloned the sub-repositories, skip the :code:`git project init` step, but make sure the sub-repositories are listed in your .gitignore.
 
 
 Usage
@@ -56,7 +60,7 @@ each repository.
 To save the *state*, call :code:`git project save` to save the current state of all subrepositories 
 
 .. tip:: 
-    To save only certain specified repositories, use :code:`git project save -- repo1 repo2 ...` 
+    To save only certain specified repositories, use :code:`git project save -- repo1-name repo2-name ...` 
 
 This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
 You should then add and commit the .gitproj file like normal: :code:`git add .gitproj && git commit -m "Update gitproj"`
@@ -70,7 +74,7 @@ To return to this *state* later, just switch to the branch in your base reposito
     If you want to load the exact commits on detached heads rather than resetting your local branch, use :code:`git project load --commit`.
 
 .. tip::
-    Similar to saving, you can load only specific repositories with :code:`git project load -- repo1 repo2`
+    Similar to saving, you can load only specific repositories with :code:`git project load -- repo1-name repo2-name`
 
 Optional parameters are:
 

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Similar to saving, you can load only specific repositories with
 Other
 =====
 
-Optional parameters are:
+Optional flags you can pass to :code:`git project` include:
 
 :code:`--autoclone (-a)`: Autoclone repos in .gitproj that aren't in the directory
 

--- a/README.rst
+++ b/README.rst
@@ -32,17 +32,19 @@ To uninstall, simply run :code:`make uninstall`
 Setup
 -----
 
-To setup, first create a .gitproj file with the format
+1. Create a .gitproj file with the format
 
 ::
 
     repos:
-        sub-repo-name sub-repo-url
-        sub-repo2-name sub-repo2-url
+        subrepo1-name local/path/to/repo1 remote-url-subrepo1
+        subrepo2-name local/path/to/repo2 remote-url-subrepo2
 
-Then run :code:`git project init` from the root of your project. This will attempt to clone the sub-repositories
-and add them to your .gitignore. If you have already cloned the sub-repositories, skip this step, but make sure
-the sub-repositories are listed in your .gitignore.
+2. Run :code:`git project init` from the root of your project. This will attempt to clone the sub-repositories
+and add them to your .gitignore. 
+
+.. note::
+    If you have already cloned the sub-repositories, skip running :code:`git project init`, but make sure the sub-repositories are listed in your .gitignore.
 
 
 Usage
@@ -51,13 +53,24 @@ Usage
 git-project saves the *state* of your repository and subrepositories. A *state* is the collection of feature branches for
 each repository.
 
-To save the *state*, call :code:`git project save` (or :code:`git project save -- repo1 repo2 ...` to save only given repos)
-This writes the current branches for all your subrepositories, as well as the latest commit on each branch, into the .gitproj file.
-You should then add and commit the .gitproj file
+To save the *state*, call :code:`git project save` to save the current state of all subrepositories 
 
-To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run :code:`git project load`. Note that this resets your subrepository branch to the commit stored in the .gitproj file. If you have unpushed changes in the subrepository, you will be prompted to push these before updating your branch to ensure your commits aren't orphaned.
+.. tip:: 
+    To save only certain specified repositories, use :code:`git project save -- repo1 repo2 ...` 
 
-If you want to load the exact commits from when you saved the branch (on detached heads), use :code:`git project load --commit`.
+This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
+You should then add and commit the .gitproj file like normal: :code:`git add .gitproj && git commit -m "Update gitproj"`
+
+To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run :code:`git project load`. 
+
+.. warning::
+    This resets your subrepository's local branch to the commit stored in the .gitproj file. If you have unpushed changes in the subrepository, you will be prompted to push these before updating your branch to ensure your commits aren't orphaned.
+
+.. tip::
+    If you want to load the exact commits on detached heads rather than resetting your local branch, use :code:`git project load --commit`.
+
+.. tip::
+    Similar to saving, you can load only specific repositories with :code:`git project load -- repo1 repo2`
 
 Optional parameters are:
 

--- a/README.rst
+++ b/README.rst
@@ -65,9 +65,12 @@ each repository.
 Saving
 ======
 
-To save the *state*, call :code:`git project save` to save the current state of all subrepositories 
+To save the current *state* of all subrepositories, call 
+    :code:`git project save`
 
-To save only certain specified repositories, use :code:`git project save -- repo1-name repo2-name ...` 
+To save only certain specified repositories, use 
+
+    :code:`git project save -- repo1-name repo2-name ...` 
 
 This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
 You should then add and commit the .gitproj file like normal:
@@ -77,13 +80,19 @@ You should then add and commit the .gitproj file like normal:
 Loading
 =======
 
-To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run :code:`git project load`. 
+To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run 
+
+    :code:`git project load`. 
 
 This resets your subrepository's local branch to the commit stored in the .gitproj file. If you have unpushed changes in the subrepository, you will be prompted to push these before updating your branch to ensure your commits aren't orphaned.
 
-If you want to load the exact commits on detached heads rather than resetting your local branch, use :code:`git project load --commit`.
+If you want to load the exact commits on detached heads rather than resetting your local branch, use 
 
-Similar to saving, you can load only specific repositories with :code:`git project load -- repo1-name repo2-name`
+    :code:`git project load --commit`.
+
+Similar to saving, you can load only specific repositories with 
+
+    :code:`git project load -- repo1-name repo2-name`
 
 
 Other
@@ -94,8 +103,11 @@ Optional parameters are:
 :code:`--autoclone (-a)`: Autoclone repos in .gitproj that aren't in the directory
 
 :code:`--automerge (-m)`: Automerge branch updates when loading
+
 :code:`--force (-f)`: don't prompt, will automatically merge or clone when loading, and overwrite .gitproj when saving
+
 :code:`--update (-u)`: when loading, will update all branches to the most recent commit on the saved branch (rather than the saved commit).
+
 :code:`--`: separates flags from the list of repos to save/load. If not specified, all repos will be saved/loaded
 
 

--- a/README.rst
+++ b/README.rst
@@ -34,21 +34,22 @@ Setup
 
 1. Create a .gitproj file with the format
 
-::
+    ::
 
-    repos:
-        subrepo1-name local/path/to/repo1 remote-url-subrepo1
-        subrepo2-name local/path/to/repo2 remote-url-subrepo2
+        repos:
+            subrepo1-name local/path/to/repo1 remote-url-subrepo1
+            subrepo2-name local/path/to/repo2 remote-url-subrepo2
 
-The first column (subrepo-name) is a memorable key for each repository that you will use when saving or loading that repo (see below)
-The second column is the local directory where you would like to store each repository (relative to the .gitproj file)
-The final column is the remote url from which to clone the repository.
+    The first column (subrepo-name) is a memorable key for each repository that you will use when saving or loading that repo (see below).
 
-2. Run :code:`git project init` from the root of your project. This will attempt to clone the sub-repositories
-and add them to your .gitignore. 
+    The second column is the local directory where you would like to store each repository (relative to the .gitproj file).
 
-.. note::
-If you have already cloned the sub-repositories, skip the :code:`git project init` step, but make sure the sub-repositories are listed in your .gitignore.
+    The final column is the remote url from which to clone the repository.
+
+2. Run :code:`git project init` from the root of your project. This will attempt to clone the sub-repositories and add them to your .gitignore. 
+
+    .. note::
+        If you have already cloned the sub-repositories, skip the :code:`git project init` step, but make sure the sub-repositories are listed in your .gitignore.
 
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -70,21 +70,20 @@ To save the *state*, call :code:`git project save` to save the current state of 
 To save only certain specified repositories, use :code:`git project save -- repo1-name repo2-name ...` 
 
 This writes the current branch as well as the latest commit on that branch for each subrepository, into the .gitproj file.
-You should then add and commit the .gitproj file like normal: :code:`git add .gitproj && git commit -m "Update gitproj"`
+You should then add and commit the .gitproj file like normal:
+
+    :code:`git add .gitproj && git commit -m "Update gitproj"`
 
 Loading
 =======
 
 To return to this *state* later, just switch to the branch in your base repository where you saved the state, and run :code:`git project load`. 
 
-.. warning::
-    This resets your subrepository's local branch to the commit stored in the .gitproj file. If you have unpushed changes in the subrepository, you will be prompted to push these before updating your branch to ensure your commits aren't orphaned.
+This resets your subrepository's local branch to the commit stored in the .gitproj file. If you have unpushed changes in the subrepository, you will be prompted to push these before updating your branch to ensure your commits aren't orphaned.
 
-.. tip::
-    If you want to load the exact commits on detached heads rather than resetting your local branch, use :code:`git project load --commit`.
+If you want to load the exact commits on detached heads rather than resetting your local branch, use :code:`git project load --commit`.
 
-.. tip::
-    Similar to saving, you can load only specific repositories with :code:`git project load -- repo1-name repo2-name`
+Similar to saving, you can load only specific repositories with :code:`git project load -- repo1-name repo2-name`
 
 
 Other
@@ -92,13 +91,12 @@ Other
 
 Optional parameters are:
 
-::
+:code:`--autoclone (-a)`: Autoclone repos in .gitproj that aren't in the directory
 
-    --autoclone (-a): Autoclone repos in .gitproj that aren't in the directory
-    --automerge (-m): Automerge branch updates when loading
-    --force (-f): don't prompt, will automatically merge or clone when loading, and overwrite .gitproj when saving
-    --update (-u): when loading, will update all branches to the most recent commit on the saved branch (rather than the saved commit).
-    -- : when saving, separates flags from the list of repos to save. If not specified, all repos will be saved
+:code:`--automerge (-m)`: Automerge branch updates when loading
+:code:`--force (-f)`: don't prompt, will automatically merge or clone when loading, and overwrite .gitproj when saving
+:code:`--update (-u)`: when loading, will update all branches to the most recent commit on the saved branch (rather than the saved commit).
+:code:`--`: separates flags from the list of repos to save/load. If not specified, all repos will be saved/loaded
 
 
 ****

--- a/git-project
+++ b/git-project
@@ -12,6 +12,10 @@ cwd = os.getcwd()
 FLAGS = argv[2:]
 PROMPT_ENABLED = True if '--prompt' in FLAGS else False
 
+CURRENT_VERSION = '1.0.0'
+
+using_version = '0.0.0'
+
 
 def flag_dec(func):
     """flags to check function call
@@ -44,6 +48,34 @@ def finish(exitcode=0):
 def usage(exitcode=0):
     print "Usage: git project <init|save|load> [--repos <repos>]"
     finish(exitcode)
+
+
+def check_version(v1):
+    version_diff = 0
+
+    v1_arr = v1.split('.')
+    v2_arr = CURRENT_VERSION.split('.')
+
+    if v1_arr[0] > v2_arr[0]:
+        version_diff = 1
+    elif v1_arr[0] < v2_arr[0]:
+        version_diff = -1
+    elif v1_arr[1] > v2_arr[1]:
+        version_diff = 1
+    elif v1_arr[1] < v2_arr[1]:
+        version_diff = -1
+    elif v1_arr[2] > v2_arr[2]:
+        version_diff = 1
+    elif v1_arr[2] < v2_arr[2]:
+        version_diff = -1
+
+    if version_diff < 0:
+        print '.gitproj uses older version of git-project. Consider upgrading.'
+    elif version_diff > 0:
+        print 'git-project install is out of date. .gitproj version: {}, git-project version: {}. Aborting'.format(using_version, CURRENT_VERSION)
+        finish(1)
+    else:
+        print 'Using .gitproj {}'.format(CURRENT_VERSION)
 
 
 if argc < 2:
@@ -169,23 +201,49 @@ with open(gitproj_location) as f:
 subrepos = []
 subrepo_info = {}
 parsing = 0
+firstline = True
 for line in lines:
-    if parsing == 0 and line == 'repos:':
+    splitline = line.split(' ')
+    if parsing == 0 and splitline[0] == 'version:':
+        using_version = splitline[1]
+        check_version(using_version)
+    elif parsing == 0 and line == 'repos:':
         parsing = 1
+        if firstline:
+            using_version = '0.0.0'
+            check_version(using_version)
     elif parsing == 1 and line == 'states:':
         parsing = 2
     elif parsing == 1:
         # parse subrepos info
         info = line.split(' ')
-        subrepo_info[info[0]] = {'remote': info[1]}
-        subrepos.append(info[0])
+        if using_version == '0.0.0':
+            repo = info[0]
+            local = repo
+            remote = info[1]
+        else:
+            repo = info[0]
+            local = info[1]
+            remote = info[2]
+
+        subrepo_info[repo] = {
+            'local': local,
+            'remote': remote
+        }
+        subrepos.append(repo)
     elif parsing == 2:
         info = line.split(' ')
-        if info[0] not in subrepo_info:
+        repo = info[0]
+        branch = info[1]
+        commit = info[2]
+        if repo not in subrepo_info:
             print('Error parsing .gitproj. Unknown repo {}'.format(info[0]))
             finish(1)
-        subrepo_info[info[0]]['branch'] = info[1].strip()
-        subrepo_info[info[0]]['commit'] = info[2].strip()
+        subrepo_info[repo]['branch'] = branch.strip()
+        subrepo_info[repo]['commit'] = commit.strip()
+
+    firstline = False
+
 
 # ------------------------------------------------------------------------
 # init case
@@ -194,21 +252,28 @@ if MODE == 'init':
 
     for repo in subrepos:
         repo_info = subrepo_info[repo]
+        local = repo_info['local']
         url = repo_info['remote']
 
         print 'cloning repo {} from {}'.format(repo, url)
 
         if not os.path.exists(repo):
-            if subprocess.call('git clone {} {}'.format(url, repo), shell=True) != 0:
-                print 'Error encountered while cloning repo {}'.format(repo)
+            result = subprocess.call(
+                'git clone {} {}'.format(url, local),
+                shell=True)
+            if result != 0:
+                print 'Error cloning repository {}'.format(repo)
                 finish(1)
-            subprocess.call('echo "{}" >> .gitignore'.format(repo), shell=True)
+            subprocess.call(
+                'echo "{}" >> .gitignore'.format(local),
+                shell=True
+            )
         else:
             print 'repo already exists!'
 
 elif MODE == 'status':
 
-    print 'TO BE IMPLEMENTED'
+    print 'TO BE IMPLEMENTED. Use "cat .gitproj" instead.'
 
 elif MODE == 'save':
 
@@ -233,9 +298,16 @@ elif MODE == 'save':
 
     for repo in repos_to_update:
         repo_info = subrepo_info[repo]
-        os.chdir(repo)
-        branch = subprocess.check_output('git branch | grep "*" | awk \'{ print $2 }\'', shell=True).strip()
-        commit = subprocess.check_output('git log | head -n1 | awk \'{ print $2 }\'', shell=True).strip()
+        local = repo_info['local']
+        os.chdir(local)
+        branch = subprocess.check_output(
+            'git branch | grep "*" | awk \'{ print $2 }\'',
+            shell=True
+        ).strip()
+        commit = subprocess.check_output(
+            'git log | head -n1 | awk \'{ print $2 }\'',
+            shell=True
+        ).strip()
 
         repo_info['branch'] = branch
         repo_info['commit'] = commit
@@ -244,9 +316,13 @@ elif MODE == 'save':
 
     with open(gitproj_location, 'w') as f:
         # iterate through subrepos (to ensure we preserve order)
+        f.write('version: {}\n'.format(using_version))
         f.write('repos:\n')
         for repo in subrepos:
-            f.write('\t{} {}\n'.format(repo, subrepo_info[repo]['remote']))
+            repo_info = subrepo_info[repo]
+            local = repo_info['local']
+            remote = repo_info['remote']
+            f.write('\t{} {} {}\n'.format(repo, local, remote))
 
         f.write('states:\n')
         for repo in subrepos:
@@ -271,7 +347,7 @@ elif MODE == 'load':
         print 'No Saved State to load'
         finish(1)
 
-    print '***{}***'.format(BASE)
+    print '\n\n***Loading {}***\n\n'.format(BASE)
 
     branch = subprocess.check_output('git branch | grep "*" | awk \'{print $2}\'', shell=True).strip()
 
@@ -301,18 +377,19 @@ elif MODE == 'load':
     for repo in subrepos:
 
         repo_info = subrepo_info[repo]
+        local = repo_info['local']
         branch = repo_info['branch']
         commit = repo_info['commit']
 
         # clone repo if it doesn't exist
         try:
-            os.chdir(repo)
+            os.chdir(local)
         except OSError:
             if autoclone or force:
                 clone = 'y'
             else:
                 while True:
-                    print 'Unknown sub-repo {}, do you want to try to clone it? [y/n/q] '.format(repo)
+                    print 'Unknown sub-repo {}, do you want to try to clone it? [y/n/q] '.format(local)
                     clone = sys.stdin.read(1)
                     if clone == 'q':
                         finish(0)
@@ -331,11 +408,11 @@ elif MODE == 'load':
                     print 'Error cloning repo {}'.format(repo)
                     finish(1)
 
-                os.chdir(repo)
+                os.chdir(local)
             elif clone == 'n':
                 continue
 
-        print '***{}***'.format(repo)
+        print '\n\n***Loading {}***\n\n'.format(repo)
 
         if usecommit:
             res = subprocess.call('git checkout {}'.format(commit), shell=True)
@@ -388,47 +465,3 @@ elif MODE == 'load':
 
 
 finish(0)
-
-# --- old code for git project status ---
-
-#     columnExists=false
-#     hash column 2>/dev/null
-#     if [ $? -eq 0 ] ; then
-#         columnExists=true
-#     fi
-#
-#     output=""
-#     while read -r line || [[ -n "$line" ]]; do
-#         repo=`echo $line | awk '{print $1}'`;
-#
-#         cd $repo;
-#         if [ $? -ne 0 ]; then
-#             output="$output\n$repo >>>>>DOES NOT EXIST. CLONE FIRST<<<<<"
-#         else
-#             branch=$(git branch | grep "*" | awk '{ print $2 }')
-#             commit=$(git log | head -n1 | awk '{print $2}')
-#             output="$output\n$repo $branch $commit"
-#         fi
-#         cd - >> /dev/null
-#     done <<< "$subrepos"
-#
-#     echo ""
-#     echo "-----CURRENT STATE (to be written on 'git project save')-----"
-#     echo ""
-#     if $columnExists ; then
-#         echo -e "$output" | column -t
-#     else
-#         echo -e "$output"
-#     fi
-#
-#     echo ""
-#
-#     echo "-----SAVED STATE (currently in .gitproj)-----"
-#     echo ""
-#
-#     if $columnExists ; then
-#         sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$' | column -t
-#     else
-#         sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$'
-#     fi
-#     echo ""

--- a/git-project
+++ b/git-project
@@ -324,13 +324,17 @@ elif MODE == 'save':
 
     with open(gitproj_location, 'w') as f:
         # iterate through subrepos (to ensure we preserve order)
-        f.write('version: {}\n'.format(using_version))
+        if using_version != '0.0.0':
+            f.write('version: {}\n'.format(using_version))
         f.write('repos:\n')
         for repo in subrepos:
             repo_info = subrepo_info[repo]
             local = repo_info['local']
             remote = repo_info['remote']
-            f.write('\t{} {} {}\n'.format(repo, local, remote))
+            if using_version != '0.0.0':
+                f.write('\t{} {} {}\n'.format(repo, local, remote))
+            else:
+                f.write('\t{} {}\n'.format(repo, remote))
 
         f.write('states:\n')
         for repo in subrepos:

--- a/git-project
+++ b/git-project
@@ -70,7 +70,7 @@ def check_version(v1):
         version_diff = -1
 
     if version_diff < 0:
-        print '.gitproj uses older version of git-project. Consider upgrading.'
+        print '\n WARNING: .gitproj uses older version of git-project. Consider upgrading.'
     elif version_diff > 0:
         print 'git-project install is out of date. .gitproj version: {}, git-project version: {}. Aborting'.format(using_version, CURRENT_VERSION)
         finish(1)

--- a/git-project
+++ b/git-project
@@ -12,7 +12,7 @@ cwd = os.getcwd()
 FLAGS = argv[2:]
 PROMPT_ENABLED = True if '--prompt' in FLAGS else False
 
-CURRENT_VERSION = '1.0.0'
+CURRENT_VERSION = '0.1.0'
 
 using_version = '0.0.0'
 

--- a/git-project
+++ b/git-project
@@ -46,7 +46,7 @@ def finish(exitcode=0):
 
 
 def usage(exitcode=0):
-    print "Usage: git project <init|save|load> [--repos <repos>]"
+    print "Usage: git project <init|save|load|version> [-- <subrepos>]"
     finish(exitcode)
 
 

--- a/git-project
+++ b/git-project
@@ -285,7 +285,7 @@ elif MODE == 'save':
         char = 'a'
         while True:
             print 'Saved State already exists. Overwrite? [y/n/q]'
-            char = sys.stdin.read(1)
+            char = sys.stdin.readline().strip()
             if char == 'q' or char == 'n':
                 finish(0)
             elif char == 'y':
@@ -361,7 +361,7 @@ elif MODE == 'load':
             else:
                 while True:
                     print 'There are new commits in {}:{}. Do you want to merge them in? [y/n/q] '.format(BASE, branch)
-                    merge = sys.stdin.read(1)
+                    merge = sys.stdin.readline().strip()
                     if merge == 'q':
                         finish(0)
                     elif merge == 'y' or merge == 'n':
@@ -389,8 +389,9 @@ elif MODE == 'load':
                 clone = 'y'
             else:
                 while True:
-                    print 'Unknown sub-repo {}, do you want to try to clone it? [y/n/q] '.format(local)
-                    clone = sys.stdin.read(1)
+                    print '\n\nUnknown sub-repo {}, do you want to try to clone it? [y/n/q] '.format(local)
+                    clone = sys.stdin.readline().strip()
+
                     if clone == 'q':
                         finish(0)
                     elif clone == 'y' or clone == 'n':
@@ -430,7 +431,7 @@ elif MODE == 'load':
                 else:
                     while True:
                         print 'You have un-pushed work in {}. Attempt to push to default remote? [y/n/q]'.format(repo)
-                        push = sys.stdin.read(1)
+                        push = sys.stdin.readline().strip()
                         if push == 'q':
                             finish(0)
                         elif push == 'y' or push == 'n':
@@ -453,7 +454,7 @@ elif MODE == 'load':
                         else:
                             while True:
                                 print 'There are new commits on {}:{}, merge? [y/n/q] '.format(repo, branch)
-                                merge = sys.stdin.read(1)
+                                merge = sys.stdin.readline().strip()
                                 if merge == 'q':
                                     finish(0)
                                 elif merge == 'y' or merge == 'n':

--- a/git-project
+++ b/git-project
@@ -405,7 +405,7 @@ elif MODE == 'load':
                 branch = subrepo_info[repo]['branch']
 
                 print 'Attempting to clone {} from {}'.format(repo, url)
-                if subprocess.call('git clone {} {} -b {}'.format(url, repo, branch), shell=True) != 0:
+                if subprocess.call('git clone {} {} -b {}'.format(url, local, branch), shell=True) != 0:
                     print 'Error cloning repo {}'.format(repo)
                     finish(1)
 

--- a/git-project
+++ b/git-project
@@ -82,6 +82,29 @@ if argc < 2:
     usage(1)
 
 
+darwin = False
+if subprocess.check_output('uname', shell=True).strip() == 'Darwin':
+    darwin = True
+
+if darwin:
+    sedi = '/usr/bin/sed -i .bak'
+else:
+    sedi = 'sed -i'
+
+# --- Determine Mode ---
+
+MODE = argv[1]
+
+if MODE not in ['init', 'save', 'load', 'status', 'version']:
+    usage(1)
+
+if MODE == 'version':
+    print CURRENT_VERSION
+    finish(0)
+
+
+# --- Find .gitproj ---
+
 root = subprocess.check_output(
     'git rev-parse --show-toplevel', shell=True).strip()
 
@@ -139,21 +162,6 @@ else:
 gitproj_location = os.path.abspath('.gitproj')
 
 BASE = os.path.dirname(gitproj_location).split(os.sep)[-1]
-
-darwin = False
-if subprocess.check_output('uname', shell=True).strip() == 'Darwin':
-    darwin = True
-
-if darwin:
-    sedi = '/usr/bin/sed -i .bak'
-else:
-    sedi = 'sed -i'
-
-MODE = argv[1]
-
-if MODE not in ['init', 'save', 'load', 'status']:
-    usage(1)
-
 
 force = False
 autopush = False

--- a/test/test_backwards_compatibility.py
+++ b/test/test_backwards_compatibility.py
@@ -1,0 +1,88 @@
+#!bin/env python
+
+import subprocess
+import os.path
+import unittest, re
+
+
+class TestSaveLoad(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+
+        subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
+
+        subprocess.call('mkdir remote; mkdir local', shell=True)
+        subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child2; cd child2; git init --bare', shell=True)
+
+        subprocess.call('cd local;  git clone ../remote/parent', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child2', shell=True)
+
+        subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tchild/child2 ../../remote/child2" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+
+    def test_init(self):
+
+        subprocess.call('cd local/parent;  git project init', shell=True)
+        subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
+
+        output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
+        self.assertEqual(output, 'child\n')
+
+        output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
+
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+
+        output = subprocess.check_output('cd local/parent/child; ls | grep child2 | awk \'{print $1}\'', shell=True)
+        self.assertEqual(output, 'child2\n')
+
+        output = subprocess.check_output('cd local/parent/child/child2; git remote show origin | grep Fetch | grep remote/child2 | wc -l', shell=True)
+
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+
+        subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+        subprocess.call('cd local/parent/child/child2; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+
+
+        subprocess.call('cd local/parent; git project save -f', shell=True)
+
+        subprocess.call('cd local/parent; git add .gitproj; git commit -m "Save Sub-Repository State"', shell=True)
+
+
+        self.assertTrue(os.path.isfile('local/parent/.gitproj'))
+
+        output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
+
+        self.assertEqual(output, 'child master\nchild/child2 master\n')
+
+        subprocess.call('cd local/parent; git checkout -b dev; cd child; git checkout -b dev; cd child2; git checkout -b feature', shell=True)
+
+        subprocess.call('cd local/parent; git project save -f', shell=True)
+
+        subprocess.call('cd local/parent; git add .gitproj; git commit -m "Save Sub-Repository State"', shell=True)
+
+
+        output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
+        self.assertEqual(output, 'child dev\nchild/child2 feature\n')
+
+        subprocess.call('cd local/parent; git checkout master; git project load', shell=True)
+
+        output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
+        self.assertEqual(output, 'child master\nchild/child2 master\n')
+
+
+    @classmethod
+    def tearDownClass(self):
+
+        subprocess.call('rm -rf remote local', shell=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -2,7 +2,7 @@
 
 import subprocess
 import os.path
-import unittest, re
+import unittest
 
 
 class TestInstall(unittest.TestCase):

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -23,7 +23,7 @@ class TestInstall(unittest.TestCase):
             output = subprocess.check_output('git project', shell=True)
         except subprocess.CalledProcessError as err:
             print err.output
-            self.assertEqual('Usage: git project <init|save|load> [--repos <repos>]\n', err.output)
+            self.assertEqual('Usage: git project <init|save|load|version> [-- <subrepos>]\n', err.output)
             self.assertEqual(1, err.returncode)
 
         subprocess.call('rm .gitproj', shell=True)

--- a/test/test_newBranch.py
+++ b/test/test_newBranch.py
@@ -26,7 +26,7 @@ class TestNewBranch(unittest.TestCase):
         print '\n\n CREATING .GITPROJ \n\n'
 
         # initialize the git-project for local/parent
-        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)

--- a/test/test_newBranch.py
+++ b/test/test_newBranch.py
@@ -10,6 +10,8 @@ class TestNewBranch(unittest.TestCase):
     @classmethod
     def setUpClass(self):
 
+        print '\n\n INITIALIZING REPOS \n\n'
+
         # clean up, just in case
         subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
 
@@ -21,14 +23,21 @@ class TestNewBranch(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/parent', shell=True)
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
 
+        print '\n\n CREATING .GITPROJ \n\n'
+
         # initialize the git-project for local/parent
+        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+        print '\n\n DO git project init \n\n'
 
         # clone the child repo into the parent through git project init
         subprocess.call('cd local/parent;  git project init', shell=True)
         subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
+
+        print '\n\n DO git project save \n\n'
 
         subprocess.call('cd local/parent;  git project save --force', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "save initial state"; git push', shell=True)
@@ -42,6 +51,9 @@ class TestNewBranch(unittest.TestCase):
         output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
         self.assertEqual(output.strip().replace('\n',''), '1')
 
+
+        print '\n\n CHECKOUT new branch \n\n'
+
         # create a feature branch on the child that the parent does not know about
         subprocess.call('cd local/child; git checkout -b feature_branch', shell=True)
         subprocess.call('cd local/child; echo "ASDF" >> test.txt; git add test.txt; git commit -m "feature"; git push -u origin feature_branch', shell=True)
@@ -49,10 +61,10 @@ class TestNewBranch(unittest.TestCase):
         output = subprocess.check_output('cd local/child; git show | head -n1 | awk \'{print $2}\'', shell=True)
 
         # add the feature branch and commit to parent's .gitproj
-        subprocess.call('cd local/parent; cat .gitproj | head -n3 > .gitproj.bak', shell=True)
+        subprocess.call('cd local/parent; cat .gitproj | head -n4 > .gitproj.bak', shell=True)
         subprocess.call('cd local/parent; cat .gitproj.bak > .gitproj', shell=True)
         subprocess.call('cd local/parent; rm .gitproj.bak', shell=True)
-        subprocess.call('cd local/parent; echo "\tchild feature_branch {}" >> .gitproj'.format(output.strip()), shell=True)
+        subprocess.call('cd local/parent; echo "\tc feature_branch {}" >> .gitproj'.format(output.strip()), shell=True)
 
         # commit the .gitproj
         subprocess.call('cd local/parent; git add -u; git commit -m "update gitproj"; git push', shell=True)
@@ -66,7 +78,6 @@ class TestNewBranch(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-
         subprocess.call('rm -rf remote local', shell=True)
 
 if __name__ == '__main__':

--- a/test/test_noOverwrite.py
+++ b/test/test_noOverwrite.py
@@ -22,7 +22,7 @@ class TestNoOverwrite(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
 
         # initialize the git-project for local/parent
-        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)

--- a/test/test_noOverwrite.py
+++ b/test/test_noOverwrite.py
@@ -22,8 +22,9 @@ class TestNoOverwrite(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
 
         # initialize the git-project for local/parent
+        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
 
         # clone the child repo into the parent through git project init

--- a/test/test_old_version.py
+++ b/test/test_old_version.py
@@ -1,0 +1,49 @@
+#!bin/env python
+
+import subprocess
+import os.path
+import unittest, re
+
+
+class TestOldVersion(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+
+        subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
+
+        subprocess.call('mkdir remote; mkdir local', shell=True)
+        subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child2; cd child2; git init --bare', shell=True)
+
+        subprocess.call('cd local;  git clone ../remote/parent', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child2', shell=True)
+
+        subprocess.call('cd local/parent;  echo "version: 99999999.9.9" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc2 child/child2 ../../remote/child2" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+
+    def test_init(self):
+        version = subprocess.check_output('git project version', shell=True).strip()
+
+        try:
+            subprocess.check_output('cd local/parent;  git project init', shell=True)
+        except subprocess.CalledProcessError as err:
+            self.assertEqual('git-project install is out of date. .gitproj version: 99999999.9.9, git-project version: {}. Aborting'.format(version), err.output.strip())
+            self.assertEqual(1, err.returncode)
+
+        subprocess.call('cd local/parent; rm .gitproj', shell=True)
+
+
+    @classmethod
+    def tearDownClass(self):
+
+        subprocess.call('rm -rf remote local', shell=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_safety.py
+++ b/test/test_safety.py
@@ -22,8 +22,9 @@ class TestSafety(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
 
         # initialize the git-project for local/parent
+        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
 
         # clone the child repo into the parent through git project init

--- a/test/test_safety.py
+++ b/test/test_safety.py
@@ -22,7 +22,7 @@ class TestSafety(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
 
         # initialize the git-project for local/parent
-        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)

--- a/test/test_saveSingle.py
+++ b/test/test_saveSingle.py
@@ -21,7 +21,7 @@ class TestSaveLoad(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
         subprocess.call('cd local;  git clone ../remote/child2', shell=True)
 
-        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc2 child2 ../../remote/child2" >> .gitproj', shell=True)

--- a/test/test_saveSingle.py
+++ b/test/test_saveSingle.py
@@ -21,9 +21,10 @@ class TestSaveLoad(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
         subprocess.call('cd local;  git clone ../remote/child2', shell=True)
 
+        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild2 ../../remote/child2" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc2 child2 ../../remote/child2" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
 
 
@@ -57,25 +58,25 @@ class TestSaveLoad(unittest.TestCase):
 
         output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
 
-        self.assertEqual(output, 'child master\nchild2 master\n')
+        self.assertEqual(output, 'c master\nc2 master\n')
 
         subprocess.call('cd local/parent; git checkout -b dev; cd child; git checkout -b dev; cd ../child2; git checkout -b feature', shell=True)
 
         # tests saving a single repo
-        subprocess.call('cd local/parent; git project save -f -- child', shell=True)
+        subprocess.call('cd local/parent; git project save -f -- c', shell=True)
 
         subprocess.call('cd local/parent; git add .gitproj; git commit -m "Save Sub-Repository State"', shell=True)
 
 
         output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
-        self.assertEqual(output, 'child dev\nchild2 master\n')
+        self.assertEqual(output, 'c dev\nc2 master\n')
 
-        subprocess.call('cd local/parent; git project save -f -- child2', shell=True)
+        subprocess.call('cd local/parent; git project save -f -- c2', shell=True)
 
         subprocess.call('cd local/parent; git add .gitproj; git commit -m "Save Sub-Repository State"', shell=True)
 
         output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
-        self.assertEqual(output, 'child dev\nchild2 feature\n')
+        self.assertEqual(output, 'c dev\nc2 feature\n')
 
 
 

--- a/test/test_saveload.py
+++ b/test/test_saveload.py
@@ -21,7 +21,7 @@ class TestSaveLoad(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
         subprocess.call('cd local;  git clone ../remote/child2', shell=True)
 
-        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc2 child/child2 ../../remote/child2" >> .gitproj', shell=True)

--- a/test/test_saveload.py
+++ b/test/test_saveload.py
@@ -21,9 +21,10 @@ class TestSaveLoad(unittest.TestCase):
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
         subprocess.call('cd local;  git clone ../remote/child2', shell=True)
 
+        subprocess.call('cd local/parent;  echo "version: 1.0.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
-        subprocess.call('cd local/parent;  echo "\tchild/child2 ../../remote/child2" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc2 child/child2 ../../remote/child2" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
 
 
@@ -61,7 +62,7 @@ class TestSaveLoad(unittest.TestCase):
 
         output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
 
-        self.assertEqual(output, 'child master\nchild/child2 master\n')
+        self.assertEqual(output, 'c master\nc2 master\n')
 
         subprocess.call('cd local/parent; git checkout -b dev; cd child; git checkout -b dev; cd child2; git checkout -b feature', shell=True)
 
@@ -71,12 +72,12 @@ class TestSaveLoad(unittest.TestCase):
 
 
         output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
-        self.assertEqual(output, 'child dev\nchild/child2 feature\n')
+        self.assertEqual(output, 'c dev\nc2 feature\n')
 
         subprocess.call('cd local/parent; git checkout master; git project load', shell=True)
 
         output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
-        self.assertEqual(output, 'child master\nchild/child2 master\n')
+        self.assertEqual(output, 'c master\nc2 master\n')
 
 
     @classmethod


### PR DESCRIPTION
See: CLD-2913

Adds new functionality:
`git project version`: display installed version of `git-project`

Changes to `.gitproj` format:
- first line is now the version of git-project this .gitproj is compatible with "version: x.x.x"
- repos section is now of the format `key local remote` where
    - `key` is a shortcut key for referring to a sub-repo
    - `local` is the local location of the sub-repo
    - `remote` is the remote url of the sub-repo
- states section is now of the format `key branch commit`
    - The only change here is that `key` used to be the `local` location of the repo

This makes it significantly easier to use for saving/loading individual repos:

.gitproj:
```
version: 0.1.0
repos:
    my_repo deps/frontend/my_repo <remote-url>
    be_repo1 deps/backend/my_repo1 <remote-url>
    uiRepo deps/frontend/ui/my_repo2 <remote-url>
states:
    my_repo dev asdf
    be_repo master fdsa
    uiRepo feat/asdf qwerty1
```

Before:
`git project save -- deps/frontend/my_repo`
`git project load -- deps/backend/my_repo1 deps/frontend/ui/my_repo2`

Now:
`git project save -- my_repo`
`git project save -- be_repo uiRepo`

where `my_repo`, `be_repo` and `uiRepo` are all `keys`, and the `local` locations don't change.