### PR TITLE
Fix bug where git-project would not fail when a repo failed to load

### DIFF
--- a/git-project
+++ b/git-project
@@ -457,7 +457,10 @@ elif MODE == 'load':
 
             if checkout == 'y':
                 subprocess.call('git fetch origin --prune', shell=True)
-                subprocess.call('git checkout -B {} {}'.format(branch, commit), shell=True)
+                res = subprocess.call('git checkout -B {} {}'.format(branch, commit), shell=True)
+                if res != 0:
+                    print '\n\nError checking out commit {} on branch {}. Is {} pushed?'.format(commit, branch, repo)
+                    finish(1);
 
                 if subprocess.call('git status | grep "behind"', shell=True) == 0:
                     if update or automerge or force:

--- a/test/test_loadfail.py
+++ b/test/test_loadfail.py
@@ -10,15 +10,19 @@ class TestSaveLoad(unittest.TestCase):
     @classmethod
     def setUpClass(self):
 
+        # ensure we start with a clean slate, just in case
         subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
 
+        # Initialize "remote" repositories
         subprocess.call('mkdir remote; mkdir local', shell=True)
         subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
         subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
 
+        # Initialize "local" repositories
         subprocess.call('cd local;  git clone ../remote/parent', shell=True)
         subprocess.call('cd local;  git clone ../remote/child', shell=True)
 
+        # Add a .gitproj to the parent repo, and make child a subrepo of parent
         subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
         subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
@@ -27,24 +31,28 @@ class TestSaveLoad(unittest.TestCase):
 
     def test_init(self):
 
+        # Initialize git-project (clones child into parent)
         subprocess.call('cd local/parent;  git project init', shell=True)
         subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
 
+        # Ensure child was cloned properly
         output = subprocess.call('test -d local/parent/child;', shell=True)
         self.assertEqual(output, 0)
 
+        # Ensure child's origin is set correctly
         output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
 
         self.assertEqual(output.strip(), '1')
 
+        # Add a commit to the child and update parent's .gitproj
         subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
-
         subprocess.call('cd local/parent; git project save -f', shell=True)
-
         subprocess.call('cd local/parent; git add .gitproj; git commit -m "Save Sub-Repository State"', shell=True)
 
+        # Change the .gitproj so it is invalid
         subprocess.call('cd local/parent; sed \$d .gitproj > .gitproj2; echo "    c master nonexistantcommit" >> .gitproj2', shell=True)
 
+        # Ensure loading the invalid .gitproj returns a non-zero error code
         subprocess.call('cd local/parent; mv .gitproj2 .gitproj', shell=True)
         res = subprocess.call('cd local/parent; git project load', shell=True)
         self.assertEqual(res, 1)
@@ -52,6 +60,7 @@ class TestSaveLoad(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
 
+        # Remove remote and local repos
         subprocess.call('rm -rf remote local', shell=True)
 
 if __name__ == '__main__':

--- a/test/test_loadfail.py
+++ b/test/test_loadfail.py
@@ -30,12 +30,12 @@ class TestSaveLoad(unittest.TestCase):
         subprocess.call('cd local/parent;  git project init', shell=True)
         subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
 
-        output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
-        self.assertEqual(output, 'child\n')
+        output = subprocess.call('test -d local/parent/child;', shell=True)
+        self.assertEqual(output, 0)
 
         output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
 
-        self.assertEqual(output.strip().replace('\n',''), '1')
+        self.assertEqual(output.strip(), '1')
 
         subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
 

--- a/test/test_loadfail.py
+++ b/test/test_loadfail.py
@@ -1,0 +1,58 @@
+#!bin/env python
+
+import subprocess
+import os.path
+import unittest, re
+
+
+class TestSaveLoad(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+
+        subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
+
+        subprocess.call('mkdir remote; mkdir local', shell=True)
+        subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
+
+        subprocess.call('cd local;  git clone ../remote/parent', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child', shell=True)
+
+        subprocess.call('cd local/parent;  echo "version: 0.1.0" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tc child ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+
+    def test_init(self):
+
+        subprocess.call('cd local/parent;  git project init', shell=True)
+        subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
+
+        output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
+        self.assertEqual(output, 'child\n')
+
+        output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
+
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+        subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+
+        subprocess.call('cd local/parent; git project save -f', shell=True)
+
+        subprocess.call('cd local/parent; git add .gitproj; git commit -m "Save Sub-Repository State"', shell=True)
+
+        subprocess.call('cd local/parent; sed \$d .gitproj > .gitproj2; echo "    c master nonexistantcommit" >> .gitproj2', shell=True)
+
+        subprocess.call('cd local/parent; mv .gitproj2 .gitproj', shell=True)
+        res = subprocess.call('cd local/parent; git project load', shell=True)
+        self.assertEqual(res, 1)
+
+    @classmethod
+    def tearDownClass(self):
+
+        subprocess.call('rm -rf remote local', shell=True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- For instance, when a child repo's saved branch/commit wasn't pushed
- git-project would keep going, rather than failing with a non-zero exit
code